### PR TITLE
Reset sampling before get_std_sampled_data

### DIFF
--- a/kmos/run/__init__.py
+++ b/kmos/run/__init__.py
@@ -784,6 +784,9 @@ class KMC_Model(Process):
         if show_progress:
             progress_bar = kmos.utils.progressbar.ProgressBar()
 
+        # reset sampling starting point
+        _ = self.get_atoms(geometry = False, reset_time_overrun = False)
+
         # sample over trajectory
         for sample in xrange(samples):
             self.do_steps(sample_size/samples)


### PR DESCRIPTION
Hi Max,
Mie realized there's a problem, that I consider a bug.

How to reproduce:
Take any model, and do something like this

```
nrel = 1e6; nsample = 1e6  # numerical parameters
Ts = range(450,650,20)     # 20 values between 450 and 650 K
TOFs = []                  # empty list for output
# Loop over the temperature
for T in Ts:
    model.parameters.T = T   # Set the temperature
    model.do_steps(nrel)     # Relax the system
    # Sample the reactivity
    output = model.get_std_sampled_data(1, nsample, output='dict')
    # Collect output
    TOFs.append(output['CO_oxidation'])
```

We think that this will include the 'relaxation steps' in the sampling. IMO this should not be the case. I believe this is easily solved with this patch.

Best
Juan