### PR TITLE
Installation instructions for Ubuntu

### DIFF
--- a/doc/source/tutorials/installation.rst
+++ b/doc/source/tutorials/installation.rst
@@ -5,64 +5,53 @@ You can fetch the current version of kmos using *git* ::
 
     git clone http://www.github.com/mhoffman/kmos
 
-
-and install it using *setuptools* ::
-
-    ./setup.py install [--user]
-
-
-or if you have `pip <http://www.pip-installer.org/en/latest/installing.html>`_ run ::
-
-    pip install python-kmos --upgrade [--user]
-
-To use the core functionality
-(programmatic model setup, code generation, model execution)
-kmos has a fairly modest depedency foot-print. You will need ::
-
-  python-numpy, a Fortran compiler, python-lxml
-
-In order to watch the model run on screen you will additionally
-need ::
-
-  python-matplotlib, python-ase
-
 Finally in order to use all features, in particular the GUI
 model editor of kmos you have to install
 a number of dependencies. This should not be very difficult
 on a recent Linux distribution with package management. So
 on Ubuntu it suffices to call::
 
-  sudo apt-get install gazpacho gfortran python-dev \
-                       python-glade2 python-kiwi python-lxml \
-                       python-matplotlib python-numpy \
-                       python-pygoocanvas
+    sudo apt-get install gfortran python-dev python-pip \
+                         python-glade2 python-kiwi python-pygoocanvas
 
 
-and if you haven't already installed it, one way to fetch the
-atomic simulation environment (ASE) is currently to ::
+Unfortunately Debian/Ubuntu have discontinued maintaining the `gazpacho` package
+which I find very unfortunate since it eased gtk GUI building a lot and I
+haven't found a simple transition path (simple as in one reliable conversion
+script and two changed import lines) towards gtkbuilder. Gazpacho itself depends on
+`python-support` which is not maintained by Debian/Ubuntu anymore, too.
+Therefore for the moment I can only suggest to fetch the latest `python-support` and the latest `gazpacho` package and install it manually with::
 
-  sudo add-apt-repository ppa:campos-dev/campos
-  sudo apt-get update
-  sudo apt-get install python-ase
-
-Or go to their `website <https://gitlab.com/ase/ase/repository/archive.zip?ref=master>`_
-to fetch the latest version.
-
-Unfortunately Debian/Ubuntu have discontinued maintaining the gazpacho package which I find very unfortunate since it eased gtk GUI building a lot and I haven't found a simple transition path (simple as in one reliable conversion script and two changed import lines) towards gtkbuilder. Therefore for the moment I can only suggest to fetch the latest old package from e.g. `here <https://gist.github.com/mhoffman/d2a9466c22f33a9e046b/raw/4c73c5029f3c01e656f161c7459f720aff331705/gazpacho_0.7.2-3_all.deb>`_ and install it manually with ::
-
+    wget http://ftp.de.debian.org/debian/pool/main/p/python-support/python-support_1.0.15_all.deb
+    wget https://gist.github.com/mhoffman/d2a9466c22f33a9e046b/raw/4c73c5029f3c01e656f161c7459f720aff331705/gazpacho_0.7.2-3_all.deb
+    sudo dpkg -i python-support*.deb
     sudo dpkg -i gazpacho_*.deb
 
+After that there are some python requirements you have to install via pip::
 
+    cd kmos/
+    pip install -r requirements.txt
+
+To ease the installation of requirements on Ubuntu one can simply run (this is tested with clean installations of *Ubuntu 16.04.3 LTS* and *Ubuntu 17.04*)::
+
+    cd tools/
+    ./kmos-install-dependencies-ubuntu.sh
+
+If you plan to use a specific branch (other than master) perform a `git checkout`. 
+As there a many new features in the `develop` branch currently, we use it as an example::
+
+    git checkout develop
+
+Afterwards install kmos with *setuptools* ::
+
+    cd ..
+    ./setup.py install [--user]
 
 If you think this dependency list hurts. Yes, it does!
 And I am happy about any suggestions how to
 minimize it. However one should note these dependencies are only
 required for the model development. Running a model has virtually
 no dependencies except for a Fortran compiler.
-
-To ease the installation further on Ubuntu one can simply run::
-
- kmos-install-dependencies-ubuntu
 
 
 Installation on openSUSE 12.1 Linux

--- a/doc/source/tutorials/installation.rst
+++ b/doc/source/tutorials/installation.rst
@@ -5,6 +5,22 @@ You can fetch the current version of kmos using *git* ::
 
     git clone http://www.github.com/mhoffman/kmos
 
+and install it using *setuptools* ::
+
+    cd kmos/
+    ./setup.py install [--user]
+
+To use the core functionality
+(programmatic model setup, code generation, model execution)
+kmos has a fairly modest depedency foot-print. You will need ::
+
+    python-numpy, a Fortran compiler, python-lxml
+
+In order to watch the model run on screen you will additionally
+need ::
+
+    python-matplotlib, python-ase
+
 Finally in order to use all features, in particular the GUI
 model editor of kmos you have to install
 a number of dependencies. This should not be very difficult
@@ -13,7 +29,6 @@ on Ubuntu it suffices to call::
 
     sudo apt-get install gfortran python-dev python-pip \
                          python-glade2 python-kiwi python-pygoocanvas
-
 
 Unfortunately Debian/Ubuntu have discontinued maintaining the `gazpacho` package
 which I find very unfortunate since it eased gtk GUI building a lot and I
@@ -27,24 +42,17 @@ Therefore for the moment I can only suggest to fetch the latest `python-support`
     sudo dpkg -i python-support*.deb
     sudo dpkg -i gazpacho_*.deb
 
-After that there are some python requirements you have to install via pip::
+The remaining python dependencies are installed with pip::
 
-    cd kmos/
     pip install -r requirements.txt
 
 To ease the installation of requirements on Ubuntu one can simply run (this is tested with clean installations of *Ubuntu 16.04.3 LTS* and *Ubuntu 17.04*)::
 
-    cd tools/
-    ./kmos-install-dependencies-ubuntu.sh
+    .tools/kmos-install-dependencies-ubuntu.sh
 
-If you plan to use a specific branch (other than master) perform a `git checkout`. 
-As there a many new features in the `develop` branch currently, we use it as an example::
+If you plan to use a specific branch (for example `develop`) perform a `git checkout` and run *setuptools* again::
 
     git checkout develop
-
-Afterwards install kmos with *setuptools* ::
-
-    cd ..
     ./setup.py install [--user]
 
 If you think this dependency list hurts. Yes, it does!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 lxml
-ase
+matplotlib
+ase==3.9.1

--- a/tools/kmos-install-dependencies-ubuntu
+++ b/tools/kmos-install-dependencies-ubuntu
@@ -1,33 +1,32 @@
-#!/bin/bash -eu
+#!/bin/bash
 
 # The kmos dependency list is horribly wrong
-# and right now even depends on a repository
-# which is outside the Ubuntu repositories
+# and right now even depends on two repositories
+# which are outside the Ubuntu repositories
 # let's hope that this changes soon
 # and let's see how we can cut down on this
-# list. 
+# list.
 # The goal will be to reduce this list to
 
 # python-dev gfortran python-numpy python-pygoocanvas
 
 # or something like that
 
-print "Simple wrapping script that resolves"
-print "dependency within the APT system"
+echo "Simple wrapping script that resolves"
+echo "dependency within the APT system"
 
-
-
-sudo add-apt-repository ppa:campos-dev/campos
 sudo apt-get update
+sudo apt-get install \
+     gfortran \
+     python-dev \
+     python-pip \
+     python-glade2 \
+     python-pygoocanvas \
+     python-kiwi
 
-sudo apt-get install\
-                     gazpacho \
-                     gfortran \
-                     python-ase \
-                     python-dev \
-                     python-glade2 \
-                     python-kiwi \
-                     python-lxml \
-                     python-matplotlib \
-                     python-numpy \
-                     python-pygoocanvas
+wget http://ftp.de.debian.org/debian/pool/main/p/python-support/python-support_1.0.15_all.deb
+sudo dpkg -i python-support*.deb
+wget https://gist.github.com/mhoffman/d2a9466c22f33a9e046b/raw/4c73c5029f3c01e656f161c7459f720aff331705/gazpacho_0.7.2-3_all.deb
+sudo dpkg -i gazpacho*.deb
+
+pip install -r ../requirements.txt

--- a/tools/kmos-install-dependencies-ubuntu
+++ b/tools/kmos-install-dependencies-ubuntu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # The kmos dependency list is horribly wrong
 # and right now even depends on two repositories

--- a/tools/kmos-install-dependencies-ubuntu
+++ b/tools/kmos-install-dependencies-ubuntu
@@ -29,4 +29,4 @@ sudo dpkg -i python-support*.deb
 wget https://gist.github.com/mhoffman/d2a9466c22f33a9e046b/raw/4c73c5029f3c01e656f161c7459f720aff331705/gazpacho_0.7.2-3_all.deb
 sudo dpkg -i gazpacho*.deb
 
-pip install numpy lxml maptlotlib ase==3.9.1
+pip install numpy lxml matplotlib ase==3.9.1

--- a/tools/kmos-install-dependencies-ubuntu
+++ b/tools/kmos-install-dependencies-ubuntu
@@ -29,4 +29,4 @@ sudo dpkg -i python-support*.deb
 wget https://gist.github.com/mhoffman/d2a9466c22f33a9e046b/raw/4c73c5029f3c01e656f161c7459f720aff331705/gazpacho_0.7.2-3_all.deb
 sudo dpkg -i gazpacho*.deb
 
-pip install -r ../requirements.txt
+pip install numpy lxml maptlotlib ase==3.9.1


### PR DESCRIPTION
There are several keypoints - regarding the installation process with Ubuntu >16.04 - addressed in this PR:
- gazpacho depends on python-support which is [not maintained](https://askubuntu.com/questions/766169/why-no-more-python-support-in-16-04) by Debian anymore. Hence it requires a manual installation, too
- the apt update after adding the campos-dev/campos ppa throws 404 errors. It is also is very [outdated.](https://launchpad.net/~campos-dev/+archive/ubuntu/campos)
- pip install python-kmos yields a very old version of kmos (0.3.9) This can cause confusion for newcomers and it would be better to not mention the pip installation until the PyPI packages are updated.
- for now I pinned the ase version to 3.9.1 due to #58 

A reworked installation script takes these changes into consideration. It is tested with Ubuntu 16.04, 16.10, 17.04 and the early beta of 17.10.